### PR TITLE
Goswagger 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-glide.lock
 .go.get
-swagger
 vendor/
 
 # Compiled source #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 go:
-  - 1.5.1
+  - 1.6.3
+  - 1.7.1
+  - tip
 script:
   - make install

--- a/Makefile
+++ b/Makefile
@@ -1,67 +1,38 @@
 export GO15VENDOREXPERIMENT=1
 
 GLIDE := $(GOPATH)/bin/glide
-GLIDE_YAML := glide.yaml
 GLIDE_LOCK := glide.lock
-GLIDE_SWAGGER_YAML := glide-swagger.yaml
-GO_GET := .go.get
-SWAGGER := $(GOPATH)/bin/swagger
 SWAGGER_PKG := github.com/go-swagger/go-swagger
-SWAGGER_CMD_SRC := $(SWAGGER_PKG)/cmd/swagger/swagger.go
-GOPATH_SWAGGER_CMD_SRC := $(GOPATH)/src/$(SWAGGER_CMD_SRC)
-VENDORED_SWAGGER_CMD_SRC := vendor/$(SWAGGER_CMD_SRC)
+SWAGGER_CMD := $(SWAGGER_PKG)/cmd/swagger/swagger.go
+VENDORED_SWAGGER_CMD := vendor/$(SWAGGER_CMD)
 SPEC_FILE := swagger-spec/redfish.yml
 NAME := redfish
 CLIENT := client
 MODELS := models
 CLIENT_BINDINGS := $(CLIENT)/redfish_client.go
-GOCOV := $(GOPATH)/bin/gocov
-GOVERALLS := $(GOPATH)/bin/goveralls
-COVER := $(GOPATH)/bin/cover
-COVER_OUT := cover.out
 
 all: install
-
-deps: $(CLIENT_BINDINGS) $(GO_GET)
-
-$(GO_GET): | $(GLIDE_LOCK)
-	go get -d $$($(GLIDE) nv) && touch $@
-
-$(GLIDE_LOCK): $(GLIDE_YAML) | $(GLIDE) $(CLIENT_BINDINGS)
-	$(GLIDE) --home $(HOME) up
 
 $(GLIDE):
 	go get -u github.com/Masterminds/glide
 
-$(GOPATH_SWAGGER_CMD_SRC): $(VENDORED_SWAGGER_CMD_SRC)
-$(VENDORED_SWAGGER_CMD_SRC): $(GLIDE_SWAGGER_YAML) | $(GLIDE)
-	$(GLIDE) --home $(HOME) --yaml $< up --quick --cache-gopath --use-gopath
+swagger_deps: $(GLIDE_LOCK) | $(GLIDE)
+	$(GLIDE) --home $(HOME) install
 
-client-bindings: $(CLIENT_BINDINGS)
-$(CLIENT_BINDINGS): $(VENDORED_SWAGGER_CMD_SRC) $(GOPATH_SWAGGER_CMD_SRC) $(SPEC_FILE)
-	go run $(GOPATH_SWAGGER_CMD_SRC) generate client -f $(SPEC_FILE) -A $(NAME)
+$(CLIENT_BINDINGS): swagger_deps $(SPEC_FILE)
+	go run $(VENDORED_SWAGGER_CMD) generate client -f $(SPEC_FILE) -A $(NAME)
 
-install: $(CLIENT_BINDINGS) $(GO_GET)
+install: $(CLIENT_BINDINGS)
 	go install -v $$($(GLIDE) nv)
 
 test: $(COVER_OUT)
-$(COVER_OUT):
-	go test -v $$($(GLIDE) nv) -cover -coverprofile $@
-
-cover: $(COVER_OUT) | $(GOCOV) $(GOVERALLS) $(COVER)
-	$(GOVERALLS) -coverprofile=$<
+	go test -v
 
 clean:
-	rm -fr $(GLIDE_LOCK) $(GO_GET) $(COVER_OUT) $(CLIENT) $(MODELS)
+	rm -fr $(CLIENT) $(MODELS)
 
 clobber: clean
 	rm -fr vendor
 
-clobber-gopath-swagger:
-	rm -fr $(SWAGGER)
-	rm -fr $(GOPATH)/src/$(SWAGGER_PKG)
-	rm -fr $(GOPATH)/pkg/*/$(SWAGGER_PKG)
-
-.PHONY: all deps install test cover \
-		clean clobber clobber-gopath-swagger \
-		client-bindings
+.PHONY: all swagger_deps install test \
+		clean clobber

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cd $GOPATH/src/github.com/codedellemc/gorackhd-redfish
 $ make
 ```
 
-The Makefile utilizes [glide](https://github.com/Masterminds/glide) to reference git commit `6b712512cbe` of [go-swagger](https://github.com/go-swagger/go-swagger) that has been tested and known to be working. The Makefile will generate a go-swagger directory in `/vendor/github.com/` and then create the client. 
+The Makefile utilizes [glide](https://github.com/Masterminds/glide) to reference git commit `0.6.0` of [go-swagger](https://github.com/go-swagger/go-swagger). The Makefile will generate a go-swagger directory in `/vendor/github.com/` and then create the client.
 
 ## Environment Variables
 | Name        | Description           |
@@ -38,7 +38,7 @@ import (
     "log"
     "os"
 
-    httptransport "github.com/go-openapi/runtime/client"
+    rc "github.com/go-openapi/runtime/client"
     "github.com/go-openapi/strfmt"
 
     apiclientRedfish "github.com/codedellemc/gorackhd-redfish/client"
@@ -48,7 +48,7 @@ import (
 func main() {
 
     // create the transport
-    transport := httptransport.New("localhost:9090", "/redfish/v1", []string{"http"})
+    transport := rc.New("localhost:9090", "/redfish/v1", []string{"http"})
 
     // configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
     if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -90,9 +90,11 @@ import (
 )
 ```
 
-Lookup the params that are required in a struct:
+Create the params that are required:
 ```
-resp, err := client.RedfishV1.GetSystem(&redfish_v1.GetSystemParams{Identifier: "57154fe9d67951e70958c213"})
+params := redfish_v1.NewGetSystemParams()
+params = params.WithIdentifier("57154fe9d67951e70958c213")
+resp, err := client.RedfishV1.GetSystem(params)
 if err != nil {
       log.Fatal(err)
 }

--- a/glide-swagger.yaml
+++ b/glide-swagger.yaml
@@ -1,8 +1,0 @@
-package: github.com/codedellemc/gorackhd-redfish
-ignore:
-- client
-- models
-import:
-  - package: github.com/go-swagger/go-swagger
-    version: 0.6.0
-    vcs:     git

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,80 @@
+hash: 439e72e39b58536015c6b086520325aed21ce051ee58e36ea095ce1a97759489
+updated: 2016-09-07T10:14:52.64494608-07:00
+imports:
+- name: github.com/asaskevich/govalidator
+  version: 593d64559f7600f29581a3ee42177f5dbded27a9
+  repo: https://github.com/asaskevich/govalidator
+- name: github.com/go-openapi/analysis
+  version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
+  repo: https://github.com/go-openapi/analysis
+- name: github.com/go-openapi/errors
+  version: 4178436c9f2430cdd945c50301cfb61563b56573
+  repo: https://github.com/go-openapi/errors
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+  repo: https://github.com/go-openapi/jsonpointer
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+  repo: https://github.com/go-openapi/jsonreference
+- name: github.com/go-openapi/loads
+  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38
+  repo: https://github.com/go-openapi/loads
+- name: github.com/go-openapi/runtime
+  version: 18efe8c11921c0ddabc8e91554971d6db1f91c7c
+  subpackages:
+  - client
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+  repo: https://github.com/go-openapi/spec
+- name: github.com/go-openapi/strfmt
+  version: d65c7fdb29eca313476e529628176fe17e58c488
+  repo: https://github.com/go-openapi/strfmt
+- name: github.com/go-openapi/swag
+  version: 0e04f5e499b19bf51031c01a00f098f25067d8dc
+  repo: https://github.com/go-openapi/swag
+- name: github.com/go-openapi/validate
+  version: 14872542e3bd537d6d6b9976e066ff658d41975f
+- name: github.com/go-swagger/go-swagger
+  version: 4c101d534a9bc418b0c47c4e017153f317304ca4
+  vcs: git
+- name: github.com/mailru/easyjson
+  version: 34560e358dc05e2c28f6fda2f5c9e7494a4b9b19
+  repo: https://github.com/mailru/easyjson
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+  repo: https://github.com/PuerkitoBio/purell
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  repo: https://github.com/PuerkitoBio/urlesc
+- name: golang.org/x/net
+  version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
+  repo: https://go.googlesource.com/net
+  subpackages:
+  - context
+  - context/ctxhttp
+  - idna
+  - netutil
+- name: golang.org/x/text
+  version: 09c7ea1fcb3345da09be5a32c9c52303acd1dc2c
+  repo: https://go.googlesource.com/text
+  subpackages:
+  - cases
+  - internal/gen
+  - internal/tag
+  - internal/triegen
+  - internal/ucd
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/cldr
+  - unicode/norm
+  - unicode/rangetable
+  - width
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,4 +2,3 @@ package: github.com/codedellemc/gorackhd-redfish
 import:
   - package: github.com/go-swagger/go-swagger
     version: 0.6.0
-    vcs:     git

--- a/redfish_test.go
+++ b/redfish_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	httptransport "github.com/go-openapi/runtime/client"
+	rc "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
 	apiclientRedfish "github.com/codedellemc/gorackhd-redfish/client"
@@ -17,7 +17,7 @@ import (
 func TestRedfishGetAccountsOperation(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/redfish/v1", []string{"http"})
+	transport := rc.New("localhost:9090", "/redfish/v1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -38,7 +38,7 @@ func TestRedfishGetAccountsOperation(t *testing.T) {
 func TestRedfishGetPowerStatus(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/redfish/v1", []string{"http"})
+	transport := rc.New("localhost:9090", "/redfish/v1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -48,9 +48,9 @@ func TestRedfishGetPowerStatus(t *testing.T) {
 	// create the API client, with the transport
 	client := apiclientRedfish.New(transport, strfmt.Default)
 
-	//use any function to do REST operations
-	//resp, err := client.RedfishV1.GetPower(&redfish_v1.GetPowerParams{Identifier: "52:54:be:ef:51:1b"})
-	resp, err := client.RedfishV1.GetSystem(&redfish_v1.GetSystemParams{Identifier: "57154fe9d67951e70958c213"})
+	params := redfish_v1.NewGetSystemParams()
+	params = params.WithIdentifier("57154fe9d67951e70958c213")
+	resp, err := client.RedfishV1.GetSystem(params)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestRedfishGetPowerStatus(t *testing.T) {
 func TestRedfishShutdown(t *testing.T) {
 
 	// create the transport
-	transport := httptransport.New("localhost:9090", "/redfish/v1", []string{"http"})
+	transport := rc.New("localhost:9090", "/redfish/v1", []string{"http"})
 
 	// configure the host. include port with environment variable. For instance the vagrant image would be localhost:9090
 	if os.Getenv("GORACKHD_ENDPOINT") != "" {
@@ -76,7 +76,10 @@ func TestRedfishShutdown(t *testing.T) {
 	action := &models.RackHDResetActionResetAction{
 		ResetType: &resetType,
 	}
-	resp, err := client.RedfishV1.DoReset(&redfish_v1.DoResetParams{Identifier: "57154fe9d67951e70958c213", Payload: action})
+	params := redfish_v1.NewDoResetParams()
+	params = params.WithIdentifier("57154fe9d67951e70958c213")
+	params = params.WithPayload(action)
+	resp, err := client.RedfishV1.DoReset(params)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This brings `gorackhd-redfish` into parity with `gorackhd` in terms of build process and dependencies. We now use the same Makefile setup, and use glide to run go-swagger 0.6.0 out of the vendored directory, which wasn't happening properly before.